### PR TITLE
Add server-side rendering for sitemap XML with updated URLs and metadata

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,29 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<?xml-stylesheet type="text/xsl" href="sitemap.xsl"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://iprateek.in/</loc>
-    <priority>1.0</priority>
-    <changefreq>monthly</changefreq>
+    <loc>https://iprateek.in</loc>
     <lastmod>2025-08-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
   </url>
   <url>
     <loc>https://iprateek.in/about</loc>
-    <priority>0.9</priority>
-    <changefreq>monthly</changefreq>
     <lastmod>2025-08-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.9</priority>
   </url>
   <url>
     <loc>https://iprateek.in/skills</loc>
-    <priority>0.8</priority>
-    <changefreq>monthly</changefreq>
     <lastmod>2025-08-06</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
   </url>
   <url>
     <loc>https://iprateek.in/projects</loc>
+    <lastmod>2025-08-06</lastmod>
+    <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://iprateek.in/contact</loc>
+    <lastmod>2025-08-06</lastmod>
+    <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 </urlset>

--- a/src/pages/sitemap.xml.tsx
+++ b/src/pages/sitemap.xml.tsx
@@ -1,0 +1,50 @@
+import { GetServerSideProps } from "next";
+
+const Sitemap = () => null;
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+  <?xml-stylesheet type="text/xsl" href="sitemap.xsl"?>
+  <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+      <loc>https://iprateek.in</loc>
+      <lastmod>2025-08-06</lastmod>
+      <changefreq>monthly</changefreq>
+      <priority>1.0</priority>
+    </url>
+    <url>
+      <loc>https://iprateek.in/about</loc>
+      <lastmod>2025-08-06</lastmod>
+      <changefreq>monthly</changefreq>
+      <priority>0.9</priority>
+    </url>
+    <url>
+      <loc>https://iprateek.in/skills</loc>
+      <lastmod>2025-08-06</lastmod>
+      <changefreq>monthly</changefreq>
+      <priority>0.8</priority>
+    </url>
+    <url>
+      <loc>https://iprateek.in/projects</loc>
+      <lastmod>2025-08-06</lastmod>
+      <changefreq>monthly</changefreq>
+      <priority>0.8</priority>
+    </url>
+    <url>
+      <loc>https://iprateek.in/contact</loc>
+      <lastmod>2025-08-06</lastmod>
+      <changefreq>monthly</changefreq>
+      <priority>0.8</priority>
+    </url>
+  </urlset>`;
+
+  res.setHeader("Content-Type", "text/xml");
+  res.write(xml);
+  res.end();
+
+  return {
+    props: {},
+  };
+};
+
+export default Sitemap;


### PR DESCRIPTION
Add sitemap stylesheet and standardize URL metadata

Enhances XML sitemap with a stylesheet reference for better browser rendering. Standardizes the structure of URL entries by:

- Adding consistent lastmod and changefreq fields across all pages
- Reordering metadata fields for better readability
- Removing trailing slash from root URL for consistency